### PR TITLE
Add default setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,5 @@
+from setuptools import setup
+
+if __name__ == "__main__":
+        setup()
+


### PR DESCRIPTION
To be fully setuptools compliant one needs a setup.py 
https://packaging.python.org/guides/distributing-packages-using-setuptools/#initial-files

I'm packaging this for NixOS, which requires the setup.py to be present